### PR TITLE
feat(auth): add discord oauth support and refactor auth flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,7 +1250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -1252,14 +1257,19 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1815,12 +1825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,16 +1885,6 @@ dependencies = [
  "security-framework 2.9.2",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2176,12 +2170,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem"
@@ -3064,21 +3052,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
-dependencies = [
- "itertools",
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3089,40 +3066,34 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "atoi",
- "byteorder",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener 5.3.0",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
  "hashlink",
- "hex",
  "indexmap",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "rustls 0.23.31",
- "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.57",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3132,9 +3103,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3145,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
@@ -3164,16 +3135,15 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.106",
- "tempfile",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -3207,16 +3177,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.57",
+ "thiserror 2.0.15",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -3228,7 +3198,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -3246,16 +3215,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.57",
+ "thiserror 2.0.15",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
@@ -3271,6 +3240,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
+ "thiserror 2.0.15",
  "tracing",
  "url",
 ]
@@ -3914,12 +3884,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ secrecy = "0.8.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 sha3 = "0.10.8"
-sqlx = { version = "0.8.2", features = [
+sqlx = { version = "0.8.6", features = [
   "runtime-tokio-rustls",
   "postgres",
   "macros",

--- a/migrations/20241201000000_oauth_providers.down.sql
+++ b/migrations/20241201000000_oauth_providers.down.sql
@@ -1,0 +1,4 @@
+-- Remove the provider column and indexes
+DROP INDEX IF EXISTS idx_sessions_user_provider;
+DROP INDEX IF EXISTS idx_sessions_provider;
+ALTER TABLE sessions DROP COLUMN IF EXISTS provider;

--- a/migrations/20241201000000_oauth_providers.up.sql
+++ b/migrations/20241201000000_oauth_providers.up.sql
@@ -1,0 +1,9 @@
+-- Add provider column to sessions table to support multiple OAuth providers
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS provider VARCHAR(50) DEFAULT 'google';
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_sessions_provider ON sessions(provider);
+CREATE INDEX IF NOT EXISTS idx_sessions_user_provider ON sessions(user_id, provider);
+
+-- Update existing sessions to have 'google' as provider
+-- UPDATE sessions SET provider = 'google' WHERE provider IS NULL; 

--- a/src/api/v1/channel.rs
+++ b/src/api/v1/channel.rs
@@ -369,7 +369,7 @@ pub async fn update_channels_in_group(
     );
 
     let InnerState {
-        email_client, db, ..
+        db, ..
     } = inner;
     let update_groups_timeout = tokio::time::Duration::from_millis(10000);
 

--- a/src/api/v1/discord_auth.rs
+++ b/src/api/v1/discord_auth.rs
@@ -1,0 +1,201 @@
+use axum::{
+    extract::{Query, State},
+    response::{IntoResponse, Redirect},
+    Json,
+};
+use chrono::Duration;
+use cookie::{Cookie, SameSite};
+use oauth2::{reqwest::async_http_client, AuthorizationCode, TokenResponse};
+use serde_json::{json, Value};
+use time::OffsetDateTime;
+use tower_cookies::Cookies;
+
+use crate::{
+    api::v1::oauth::{
+        fetch_user_profile, update_user_session, AuthRequest, OAuthProvider, Session,
+    },
+    api::v1::login::{
+        generate_token,
+    },
+    errors::AppError,
+    InnerState,
+};
+
+#[tracing::instrument(name = "Discord OAuth callback", skip(cookies, inner, query), fields(code_length = query.code.len()))]
+pub async fn discord_callback(
+    cookies: Cookies,
+    State(inner): State<InnerState>,
+    Query(query): Query<AuthRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    tracing::info!("Processing Discord OAuth callback");
+
+    let InnerState {
+        db, oauth_clients, ..
+    } = inner;
+
+    tracing::debug!("Exchanging authorization code for access token");
+    let token = oauth_clients
+        .discord
+        .exchange_code(AuthorizationCode::new(query.code))
+        .request_async(async_http_client)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to exchange Discord authorization code: {:?}", e);
+            AppError::ExternalService(anyhow::anyhow!(
+                "Failed to exchange authorization code: {}",
+                e
+            ))
+        })?;
+
+    let access_token = &token.access_token().secret();
+    let refresh_token = token.refresh_token().map(|t| t.secret()).map_or("", |v| v);
+
+    tracing::debug!("Successfully obtained Discord access token");
+
+    let user_profile = fetch_user_profile(access_token, &OAuthProvider::Discord).await?;
+    tracing::info!("Fetched Discord user profile for: {}", user_profile.email);
+
+    let expires_at = crate::api::v1::auth::calculate_token_expiry(token.expires_in()).await;
+
+    update_user_session(
+        &db,
+        &user_profile.email,
+        access_token,
+        expires_at,
+        refresh_token,
+        &OAuthProvider::Discord,
+    )
+    .await?;
+
+    tracing::info!(
+        "Discord OAuth callback completed successfully for: {}",
+        user_profile.email
+    );
+
+    // Redirect to your frontend with success
+    let frontend_url =
+        std::env::var("GROUPIFY_HOST").unwrap_or_else(|_| "https://groupify.dev".to_string());
+
+    tracing::debug!("Generating JWT token for user: {}", user_profile.email);
+    let token = generate_token(&user_profile.email, user_profile.display_name.as_deref().unwrap_or(""))?;
+    tracing::debug!("JWT token generated successfully");
+
+    let mut now = OffsetDateTime::now_utc();
+    now += time::Duration::days(60);
+
+    tracing::debug!("Retrieving GROUPIFY_HOST environment variable");
+    let domain = std::env::var("GROUPIFY_HOST")
+        .map_err(|e| {
+            tracing::error!("GROUPIFY_HOST environment variable not set: {:?}", e);
+            AppError::Unexpected(anyhow::anyhow!(e).context("GROUPIFY_HOST env var not set"))
+        })?;
+
+    tracing::debug!("Setting up authentication cookie for domain: {}", domain);
+    let mut cookie = Cookie::new("auth-token", token);
+
+    // Check if we're in development mode
+    let is_development = std::env::var("ENVIRONMENT")
+        .unwrap_or_else(|_| "production".to_string())
+        .to_lowercase() == "development";
+
+    if is_development {
+        // Development settings - works with HTTP
+        cookie.set_domain("localhost".to_string());
+        cookie.set_same_site(SameSite::Lax); // More permissive for development
+        cookie.set_secure(false); // Allow HTTP in development
+    } else {
+        // Production settings - requires HTTPS
+        let cookie_domain = if domain.starts_with('.') {
+            domain
+        } else {
+            format!(".{}", domain)
+        };
+        cookie.set_domain(cookie_domain);
+        cookie.set_same_site(SameSite::None);
+        cookie.set_secure(true);
+    }
+    
+    cookie.set_path("/");
+    cookie.set_expires(now);
+    cookie.set_http_only(true);
+    cookies.add(cookie);
+
+    let protocol = if is_development { "http" } else { "https" };
+    let redirect_url = format!(
+        "{}://{}/dashboard?auth=success&provider=discord",
+        protocol,
+        frontend_url
+    );
+
+    tracing::info!("Discord OAuth callback completed successfully for: {}", user_profile.email);
+    Ok(Redirect::to(&redirect_url))
+}
+
+#[tracing::instrument(name = "Discord login initiation")]
+pub async fn discord_login(State(inner): State<InnerState>) -> Result<impl IntoResponse, AppError> {
+    tracing::info!("Initiating Discord OAuth login");
+
+    let auth_url = crate::api::v1::oauth::generate_auth_url(
+        &inner.oauth_clients.discord,
+        &OAuthProvider::Discord,
+    );
+
+    tracing::debug!("Generated Discord auth URL: {}", auth_url);
+    Ok(Redirect::to(&auth_url))
+}
+
+#[tracing::instrument(name = "Check Discord session", skip(inner, cookies))]
+pub async fn check_discord_session(
+    State(inner): State<InnerState>,
+    cookies: Cookies,
+) -> Result<Json<Value>, AppError> {
+    tracing::info!("Checking Discord session status");
+
+    let InnerState { db, .. } = inner;
+
+    let auth_token = cookies
+        .get("auth-token")
+        .and_then(|cookie| Some(cookie.value().to_string()))
+        .ok_or_else(|| {
+            tracing::warn!("No auth token found in cookies");
+            AppError::Authentication(anyhow::anyhow!("No authentication token"))
+        })?;
+
+    let email = crate::api::v1::user::get_email_from_token(auth_token).await?;
+
+    let session: Option<Session> = sqlx::query_as::<_, Session>(
+        "SELECT * FROM sessions WHERE user_id = (SELECT id FROM users WHERE email = $1 LIMIT 1)",
+    )
+    .bind(&email)
+    .fetch_optional(&db)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to query session: {:?}", e);
+        AppError::Database(anyhow::Error::new(e).context("SQLx operation failed"))
+    })?;
+
+    match session {
+        Some(session) => {
+            let is_expired = session.expires_at < chrono::Utc::now();
+            tracing::info!(
+                "Discord session found for user: {}, expired: {}",
+                email,
+                is_expired
+            );
+
+            Ok(Json(json!({
+                "connected": true,
+                "provider": "discord",
+                "expired": is_expired,
+                "expires_at": session.expires_at
+            })))
+        }
+        None => {
+            tracing::info!("No Discord session found for user: {}", email);
+            Ok(Json(json!({
+                "connected": false,
+                "provider": "discord"
+            })))
+        }
+    }
+}

--- a/src/api/v1/mod.rs
+++ b/src/api/v1/mod.rs
@@ -4,6 +4,8 @@
 //! backward compatibility with existing clients.
 
 pub mod auth;
+pub mod discord_auth;
+pub mod oauth;
 pub mod channel;
 pub mod group;
 pub mod routes;

--- a/src/api/v1/oauth.rs
+++ b/src/api/v1/oauth.rs
@@ -1,0 +1,275 @@
+use chrono::{DateTime, Utc};
+use oauth2::{basic::BasicClient, AuthUrl, ClientId, ClientSecret, RedirectUrl, Scope, TokenUrl};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use sqlx::FromRow;
+use chrono::TimeZone;
+
+use crate::errors::AppError;
+
+#[derive(Debug, Clone)]
+pub enum OAuthProvider {
+    Google,
+    Discord,
+}
+
+impl OAuthProvider {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OAuthProvider::Google => "google",
+            OAuthProvider::Discord => "discord",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AuthRequest {
+    pub code: String,
+    pub state: Option<String>,
+}
+
+#[derive(Debug, Deserialize, FromRow)]
+pub struct Session {
+    pub id: i32,
+    pub user_id: String,
+    pub session_id: String,
+    pub refresh_token: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize, sqlx::FromRow, Clone)]
+pub struct UserProfile {
+    pub email: String,
+    pub display_name: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OAuthClients {
+    pub google: BasicClient,
+    pub discord: BasicClient,
+}
+
+#[tracing::instrument(name = "Build Google OAuth client", skip(client_id, client_secret))]
+pub fn build_google_oauth_client(client_id: String, client_secret: String) -> BasicClient {
+    tracing::info!("Building Google OAuth client");
+
+    let redirect_url = std::env::var("GOOGLE_REDIRECT_URL")
+        .unwrap_or_else(|_| "https://coolify.groupify.dev/api/auth/google_callback".to_string());
+
+    tracing::debug!("Using Google redirect URL: {}", redirect_url);
+
+    BasicClient::new(
+        ClientId::new(client_id),
+        Some(ClientSecret::new(client_secret)),
+        AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_string())
+            .expect("Invalid Google authorization endpoint URL"),
+        Some(
+            TokenUrl::new("https://www.googleapis.com/oauth2/v3/token".to_string())
+                .expect("Invalid Google token endpoint URL"),
+        ),
+    )
+    .set_redirect_uri(RedirectUrl::new(redirect_url).unwrap())
+}
+
+#[tracing::instrument(name = "Build Discord OAuth client", skip(client_id, client_secret))]
+pub fn build_discord_oauth_client(client_id: String, client_secret: String) -> BasicClient {
+    tracing::info!("Building Discord OAuth client");
+
+    let redirect_url = std::env::var("DISCORD_REDIRECT_URL")
+        .unwrap_or_else(|_| "https://coolify.groupify.dev/api/auth/discord_callback".to_string());
+
+    tracing::debug!("Using Discord redirect URL: {}", redirect_url);
+
+    BasicClient::new(
+        ClientId::new(client_id),
+        Some(ClientSecret::new(client_secret)),
+        AuthUrl::new("https://discord.com/api/oauth2/authorize".to_string())
+            .expect("Invalid Discord authorization endpoint URL"),
+        Some(
+            TokenUrl::new("https://discord.com/api/oauth2/token".to_string())
+                .expect("Invalid Discord token endpoint URL"),
+        ),
+    )
+    .set_redirect_uri(RedirectUrl::new(redirect_url).unwrap())
+}
+
+#[tracing::instrument(name = "Generate OAuth authorization URL")]
+pub fn generate_auth_url(client: &BasicClient, provider: &OAuthProvider) -> String {
+    let mut auth_request = client.authorize_url(oauth2::CsrfToken::new_random);
+
+    match provider {
+        OAuthProvider::Google => {
+            auth_request = auth_request
+                .add_scope(Scope::new("email".to_string()))
+                .add_scope(Scope::new("openid".to_string()))
+                .add_scope(Scope::new("https://www.googleapis.com/auth/youtube.readonly".to_string()))
+                .add_scope(Scope::new("profile".to_string()))
+                .set_response_type(&oauth2::ResponseType::new("code".to_string()))
+                .add_extra_param("prompt", "consent")
+                .add_extra_param("access_type", "offline");
+        }
+        OAuthProvider::Discord => {
+            auth_request = auth_request
+                .add_scope(Scope::new("identify".to_string()))
+                .add_scope(Scope::new("email".to_string()));
+        }
+    }
+
+    let (auth_url, _csrf_token) = auth_request.url();
+    auth_url.to_string()
+}
+
+#[tracing::instrument(name = "Fetch user profile", skip(access_token), fields(provider = %provider.as_str()))]
+pub async fn fetch_user_profile(
+    access_token: &str,
+    provider: &OAuthProvider,
+) -> Result<UserProfile, AppError> {
+    let client = Client::new();
+
+    let (url, auth_header) = match provider {
+        OAuthProvider::Google => (
+            "https://www.googleapis.com/oauth2/v2/userinfo",
+            format!("Bearer {}", access_token),
+        ),
+        OAuthProvider::Discord => (
+            "https://discord.com/api/users/@me",
+            format!("Bearer {}", access_token),
+        ),
+    };
+
+    tracing::debug!("Fetching user profile from: {}", url);
+
+    let response = client
+        .get(url)
+        .header("Authorization", auth_header)
+        .send()
+        .await
+        .map_err(|e| {
+            AppError::ExternalService(anyhow::anyhow!("Failed to fetch user profile: {}", e))
+        })?;
+
+    if !response.status().is_success() {
+        tracing::error!("Failed to fetch user profile: HTTP {}", response.status());
+        return Err(AppError::ExternalService(anyhow::anyhow!(
+            "Failed to fetch user profile: HTTP {}",
+            response.status()
+        )));
+    }
+
+    let user_data: Value = response.json().await.map_err(|e| {
+        AppError::ExternalService(anyhow::anyhow!("Failed to fetch user profile: {}", e))
+    })?;
+
+    tracing::debug!("Received user data: {:?}", user_data);
+
+    let profile = match provider {
+        OAuthProvider::Google => UserProfile {
+            email: user_data["email"]
+                .as_str()
+                .ok_or_else(|| {
+                    AppError::ExternalService(anyhow::anyhow!("No email in Google profile"))
+                })?
+                .to_string(),
+            display_name: user_data["name"].as_str().map(|s| s.to_string()),
+            avatar_url: user_data["picture"].as_str().map(|s| s.to_string()),
+        },
+        OAuthProvider::Discord => UserProfile {
+            email: user_data["email"]
+                .as_str()
+                .ok_or_else(|| {
+                    AppError::ExternalService(anyhow::anyhow!("No email in Discord profile"))
+                })?
+                .to_string(),
+            display_name: user_data["username"].as_str().map(|s| s.to_string()),
+            avatar_url: user_data["avatar"].as_str().map(|avatar_hash| {
+                let user_id = user_data["id"].as_str().unwrap_or("0");
+                format!(
+                    "https://cdn.discordapp.com/avatars/{}/{}.png",
+                    user_id, avatar_hash
+                )
+            }),
+        },
+    };
+
+    tracing::info!("Successfully fetched profile for: {}", profile.email);
+    Ok(profile)
+}
+
+#[tracing::instrument(name = "Update user session", skip(db, access_token, refresh_token), fields(email = %email, provider = %provider.as_str()))]
+pub async fn update_user_session(
+    db: &sqlx::PgPool,
+    email: &str,
+    access_token: &str,
+    expires_at: chrono::NaiveDateTime,
+    refresh_token: &str,
+    provider: &OAuthProvider,
+) -> Result<(), AppError> {
+    tracing::info!("Updating user session for provider: {}", provider.as_str());
+
+    // First, get or create the user
+    let user_id = get_or_create_user(db, email, provider).await?;
+
+    let _ = sqlx::query!(
+        r#"
+        INSERT INTO sessions (user_id, session_id, refresh_token, expires_at, provider)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (user_id, provider) DO UPDATE
+        SET 
+            session_id = EXCLUDED.session_id,
+            refresh_token = EXCLUDED.refresh_token,
+            expires_at = EXCLUDED.expires_at
+        "#,
+        user_id,
+        access_token,
+        refresh_token,
+        chrono::Utc.from_utc_datetime(&expires_at),
+        provider.as_str()
+    )
+    .execute(db)
+    .await
+    .map_err(|e| AppError::Database(anyhow::anyhow!("Failed to upsert user session: {}", e)))?;
+
+    tracing::info!("Successfully updated session for user: {}", email);
+    Ok(())
+}
+
+#[tracing::instrument(name = "Get or create user", skip(db), fields(email = %email, provider = %provider.as_str()))]
+async fn get_or_create_user(
+    db: &sqlx::PgPool,
+    email: &str,
+    provider: &OAuthProvider,
+) -> Result<String, AppError> {
+    // Try to find existing user
+    let user = sqlx::query_scalar::<_, String>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| {
+            AppError::Database(anyhow::Error::from(e).context("Failed to fetch user by email"))
+        })?;
+
+    if let Some(user_id) = user {
+        tracing::debug!("Found existing user: {}", user_id);
+        return Ok(user_id);
+    }
+
+    // Create new user
+    let user_id = uuid::Uuid::new_v4().to_string();
+
+    sqlx::query!(
+        r#"
+        INSERT INTO users (id, email, is_sso_user, created_at, updated_at)
+        VALUES ($1, $2, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        "#,
+        user_id,
+        email
+    )
+    .execute(db)
+    .await
+    .map_err(|e| AppError::Database(anyhow::Error::from(e).context("Failed to create user")))?;
+
+    tracing::info!("Created new user: {} for email: {}", user_id, email);
+    Ok(user_id)
+}

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -12,7 +12,8 @@ use crate::InnerState;
 use crate::api::v1::channel::{all_channels, all_channels_by_group, create_channel, update_channels_in_group, fetch_youtube_channels, save_youtube_channels};
 use crate::api::v1::group::{all_groups, create_group, delete_group, update_group};
 use crate::api::v1::link_shortner::{create_link, get_link_statistics, redirect, update_link};
-use crate::api::v1::auth::{google_callback, check_google_session};
+use crate::api::v1::auth::{google_callback, check_google_session, google_login};
+
 use crate::api::v1::subscriptions::{subscribe};
 use crate::api::v1::subscription_confirm::{confirm};
 use crate::api::v1::user::{delete_account, get_language};
@@ -20,6 +21,7 @@ use crate::api::v1::login::{login_user, logout_user};
 use crate::api::v1::youtube::{sync_channels_from_youtube};
 use crate::api::v1::survey::{insert_survey};
 use crate::authentication::{change_password, forget_password};
+use crate::api::v1::discord_auth::{discord_callback, discord_login, check_discord_session};
 
 
 /// Creates V1 API routes (existing routes for backward compatibility)
@@ -68,8 +70,14 @@ pub fn create_v1_routes(state: InnerState) -> Router<InnerState> {
         )
         
         // OAuth routes
+        .route("/auth/google", get(google_login))
         .route("/auth/google_callback", get(google_callback))
         .route("/check-google-session", get(check_google_session))
+        
+        // New Discord OAuth routes
+        .route("/auth/discord", get(discord_login))
+        .route("/auth/discord_callback", get(discord_callback))
+        .route("/auth/discord_session", get(check_discord_session))
         
         // Survey routes
         .route("/add-survey", post(insert_survey))

--- a/src/api/v1/user.rs
+++ b/src/api/v1/user.rs
@@ -223,7 +223,6 @@ pub async fn delete_account(
     let auth_token = cookies
         .get("auth-token")
         .map(|c| c.value().to_string())
-        // Consider returning AppError::AuthError if token is missing
         .ok_or_else(|| AppError::Unexpected(anyhow::anyhow!("Missing auth-token cookie")));
 
     // Now get_user_id_from_token returns Result<String, AppError>

--- a/src/api/v1/youtube.rs
+++ b/src/api/v1/youtube.rs
@@ -87,7 +87,7 @@ pub async fn sync_channels_from_youtube(
     tracing::info!("Starting YouTube channel synchronization");
     let InnerState {
         db,
-        oauth_client,
+        oauth_clients,
         ..
     } = &inner;
 
@@ -123,7 +123,7 @@ pub async fn sync_channels_from_youtube(
 
     if expires_at < Local::now() {
         tracing::info!("Session expired, renewing token for user: {}", email);
-        let _ = renew_token(db.clone(), oauth_client.clone(), email.clone()).await;
+        let _ = renew_token(db.clone(), oauth_clients.google.clone(), email.clone()).await;
         tracing::debug!("Token renewal completed");
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,14 +36,6 @@ pub enum AppError {
     Unexpected(#[from] anyhow::Error), // Catch-all for other anyhow errors
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum AuthError {
-    #[error("Invalid credentials.")]
-    InvalidCredentials(#[source] anyhow::Error),
-    #[error(transparent)]
-    UnexpectedError(#[from] anyhow::Error),
-}
-
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, error_message) = match &self {
@@ -156,14 +148,5 @@ impl From<reqwest::Error> for AppError {
         );
         
         AppError::ExternalService(anyhow::Error::new(err).context(context))
-    }
-}
-
-impl From<AuthError> for AppError {
-    fn from(err: AuthError) -> Self {
-        match err {
-            AuthError::InvalidCredentials(source) => AppError::Authentication(source.into()),
-            AuthError::UnexpectedError(source) => AppError::Unexpected(source.into()),
-        }
     }
 }


### PR DESCRIPTION
- Implement Discord OAuth authentication alongside existing Google OAuth
- Refactor auth module to support multiple OAuth providers
- Add new database migrations for OAuth provider support
- Update SQLx dependency to 0.8.6
- Improve error handling and session management
- Add new routes for Discord authentication
- Clean up unused AuthError enum and related code