### PR TITLE
fix(auth): invalidate user cache on auth and account deletion

### DIFF
--- a/src/api/v1/auth.rs
+++ b/src/api/v1/auth.rs
@@ -57,7 +57,7 @@ pub async fn google_callback(
     tracing::info!("Processing Google OAuth callback");
 
     let InnerState {
-        db, oauth_clients, ..
+        db, oauth_clients, redis_cache, ..
     } = inner;
     let domain = std::env::var("GROUPIFY_HOST").expect("GROUPIFY_HOST must be set.");
 
@@ -182,6 +182,12 @@ pub async fn google_callback(
         &original_email,
     )
     .await?;
+
+    let user_id = get_user_id_from_email(&db, &email).await?;
+    let channels_pattern = format!("user:{}:channels:*", user_id);
+    if let Err(e) = redis_cache.del_pattern(&channels_pattern).await {
+        tracing::warn!("google_callback: redis DEL channels error: {:?}", e);
+    }
 
         // Check if we're in development mode
     let is_development = std::env::var("ENVIRONMENT")

--- a/src/api/v1/discord_auth.rs
+++ b/src/api/v1/discord_auth.rs
@@ -59,7 +59,7 @@ pub async fn discord_callback(
     tracing::info!("Processing Discord OAuth callback");
 
     let InnerState {
-        db, oauth_clients, ..
+        db, oauth_clients, redis_cache, ..
     } = inner;
 
     tracing::debug!("Exchanging authorization code for access token");
@@ -163,6 +163,11 @@ pub async fn discord_callback(
 
     // Use the utility function instead of duplicated code
     setup_auth_cookie(&token, &domain, &cookies);
+
+    let channels_pattern = format!("user:{}:channels:*", user_id);
+    if let Err(e) = redis_cache.del_pattern(&channels_pattern).await {
+        tracing::warn!("discord_callback: redis DEL channels error: {:?}", e);
+    }
 
     // Check if we're in development mode
     let is_development = std::env::var("ENVIRONMENT")

--- a/src/api/v1/user.rs
+++ b/src/api/v1/user.rs
@@ -280,7 +280,7 @@ pub async fn delete_account(
     cookies: Cookies,
     State(inner): State<InnerState>,
 ) -> Result<Json<Value>, AppError> { // Changed return type
-    let InnerState { db, .. } = inner;
+    let InnerState { db, redis_cache, .. } = inner;
 
     let auth_token = cookies
         .get("auth-token")
@@ -289,6 +289,11 @@ pub async fn delete_account(
 
     // Now get_user_id_from_token returns Result<String, AppError>
     let user_id = get_user_id_from_token(auth_token?).await?;
+
+    let channels_pattern = format!("user:{}:channels:*", user_id);
+    if let Err(e) = redis_cache.del_pattern(&channels_pattern).await {
+        tracing::warn!("delete_account: redis DEL channels error: {:?}", e);
+    }
 
     sqlx::query!("DELETE FROM channels WHERE user_id = $1", &user_id)
         .execute(&db)
@@ -337,6 +342,21 @@ pub async fn delete_account(
         .execute(&db)
         .await
         .map_err(|e| AppError::Database(anyhow::Error::from(e).context("Failed to delete user")))?;
+
+    let groups_pattern = format!("user:{}:groups:*", user_id);
+    if let Err(e) = redis_cache.del_pattern(&groups_pattern).await {
+        tracing::warn!("delete_account: redis DEL groups error: {:?}", e);
+    }
+
+    let animes_pattern = format!("user:{}:animes:*", user_id);
+    if let Err(e) = redis_cache.del_pattern(&animes_pattern).await {
+        tracing::warn!("delete_account: redis DEL animes error: {:?}", e);
+    }
+
+    let groupshelf_pattern = format!("user:{}:groupshelf:*", user_id);
+    if let Err(e) = redis_cache.del_pattern(&groupshelf_pattern).await {
+        tracing::warn!("delete_account: redis DEL groupshelf error: {:?}", e);
+    }
 
     Ok(Json(json!({ "success": "true" })))
 }

--- a/src/api/v3/groups.rs
+++ b/src/api/v3/groups.rs
@@ -639,7 +639,7 @@ pub async fn sync_group_videos(
     .await
     .map_err(|e| {
         tracing::error!("No Google session found for user {}: {:?}", email, e);
-        AppError::Authentication(anyhow::anyhow!("Google session not found. Please connect your Google account."))
+        AppError::Validation(String::from("Google session not found. Please connect your Google account."))
     })?;
 
     let expires_at: chrono::DateTime<chrono::Utc> = session.get("expires_at");


### PR DESCRIPTION
Change authentication error type from AppError::Authentication to Validation for better client handling. Add Redis cache invalidation for user channels, groups, animes, and groupshelf data during OAuth callbacks and account deletion to prevent stale data.