### PR TITLE
fix(groups): use UUID for new channel IDs instead of split prefix

### DIFF
--- a/src/api/v3/groups.rs
+++ b/src/api/v3/groups.rs
@@ -317,7 +317,7 @@ pub async fn create_channel_in_group(
 
     // Create the channel
     let new_channel = channels::ActiveModel {
-        id: Set(channel_id.split('/').next().unwrap().to_string()),
+        id: Set(Uuid::new_v4().to_string()),
         group_id: Set(target_group_id.clone()),
         user_id: Set(user_id.clone()),
         name: Set(payload.name),


### PR DESCRIPTION
The previous implementation used the first part of the channel_id (before '/') as the ID, which could lead to collisions. Using UUID ensures unique identifiers for all channels.