### PR TITLE
chore: replace groupify.dev references with nestfeed.app

### DIFF
--- a/src/api/v1/discord_auth.rs
+++ b/src/api/v1/discord_auth.rs
@@ -143,7 +143,7 @@ pub async fn discord_callback(
 
     // Redirect to your frontend with success
     let frontend_url =
-        std::env::var("GROUPIFY_HOST").unwrap_or_else(|_| "https://groupify.dev".to_string());
+        std::env::var("GROUPIFY_HOST").unwrap_or_else(|_| "https://nestfeed.app".to_string());
 
     tracing::debug!("Generating JWT token for user: {} and original_email: {}", email, original_email);
 

--- a/src/api/v1/oauth.rs
+++ b/src/api/v1/oauth.rs
@@ -91,7 +91,7 @@ pub async fn exchange_apple_code(
     let client_secret = generate_apple_client_secret(&team_id, &client_id, &key_id, &private_key)?;
 
     let redirect_url = std::env::var("APPLE_REDIRECT_URL")
-        .unwrap_or_else(|_| "https://coolify.groupify.dev/api/auth/apple_callback".to_string());
+        .unwrap_or_else(|_| "https://coolify.nestfeed.app/api/auth/apple_callback".to_string());
 
     let params = serde_json::json!({
         "grant_type": "authorization_code",
@@ -127,7 +127,7 @@ pub fn build_google_oauth_client(client_id: String, client_secret: String) -> Ba
     tracing::info!("Building Google OAuth client");
 
     let redirect_url = std::env::var("GOOGLE_REDIRECT_URL")
-        .unwrap_or_else(|_| "https://coolify.groupify.dev/api/auth/google_callback".to_string());
+        .unwrap_or_else(|_| "https://coolify.nestfeed.app/api/auth/google_callback".to_string());
 
     tracing::debug!("Using Google redirect URL: {}", redirect_url);
 
@@ -149,7 +149,7 @@ pub fn build_discord_oauth_client(client_id: String, client_secret: String) -> B
     tracing::info!("Building Discord OAuth client");
 
     let redirect_url = std::env::var("DISCORD_REDIRECT_URL")
-        .unwrap_or_else(|_| "https://coolify.groupify.dev/api/auth/discord_callback".to_string());
+        .unwrap_or_else(|_| "https://coolify.nestfeed.app/api/auth/discord_callback".to_string());
 
     tracing::debug!("Using Discord redirect URL: {}", redirect_url);
 
@@ -228,7 +228,7 @@ pub fn build_apple_oauth_client(
         .expect("Failed to generate Apple client secret");
 
     let redirect_url = std::env::var("APPLE_REDIRECT_URL")
-        .unwrap_or_else(|_| "https://coolify.groupify.dev/api/auth/apple_callback".to_string());
+        .unwrap_or_else(|_| "https://coolify.nestfeed.app/api/auth/apple_callback".to_string());
 
     tracing::debug!("Using Apple redirect URL: {}", redirect_url);
 

--- a/src/api/v1/subscriptions.rs
+++ b/src/api/v1/subscriptions.rs
@@ -86,7 +86,7 @@ pub async fn send_confirmation_email(
     
     let confirmation_link = format!(
         "{}/subscriptions/confirm/{}",
-        &String::from("https://groupify.dev"),
+        &String::from("https://nestfeed.app"),
         subscription_token
     );
     tracing::debug!("Generated confirmation link: {}", confirmation_link);
@@ -97,10 +97,10 @@ pub async fn send_confirmation_email(
     let mut template_model = HashMap::new();
     template_model.insert("product_name".to_owned(), "Groupify".to_owned());
     template_model.insert("action_url".to_owned(), confirmation_link);
-    template_model.insert("support_email".to_owned(), "admin@groupify.dev".to_owned());
+    template_model.insert("support_email".to_owned(), "admin@nestfeed.app".to_owned());
     template_model.insert(
         "login_url".to_owned(),
-        "https://groupify.dev/login".to_owned(),
+        "https://nestfeed.app/login".to_owned(),
     );
 
     tracing::debug!("Sending email via email client");

--- a/src/authentication/password.rs
+++ b/src/authentication/password.rs
@@ -160,7 +160,7 @@ pub async fn send_forget_password_email(
 
     let confirmation_link = format!(
         "{}/forget-password/confirm/{}",
-        &String::from("https://groupify.dev"),
+        &String::from("https://nestfeed.app"),
         forget_password_token
     );
     tracing::debug!("Generated confirmation link: {}", confirmation_link);
@@ -172,10 +172,10 @@ pub async fn send_forget_password_email(
     let mut template_model = HashMap::new();
     template_model.insert("product_name".to_owned(), "Groupify".to_owned());
     template_model.insert("action_url".to_owned(), confirmation_link);
-    template_model.insert("support_email".to_owned(), "admin@groupify.dev".to_owned());
+    template_model.insert("support_email".to_owned(), "admin@nestfeed.app".to_owned());
     template_model.insert(
         "login_url".to_owned(),
-        "https://groupify.dev/login".to_owned(),
+        "https://nestfeed.app/login".to_owned(),
     );
 
     tracing::debug!("Sending email via email client");

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,8 +153,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "http://localhost".parse().unwrap(),
         "http://localhost:3000".parse().unwrap(),
         "https://localhost:3000".parse().unwrap(),
-        "https://groupify.dev".parse().unwrap(),
-        "https://coolify.groupify.dev".parse().unwrap(),
+        "https://nestfeed.app".parse().unwrap(),
+        "https://coolify.nestfeed.app".parse().unwrap(),
         "https://www.youtube.com".parse().unwrap(),
         "https://youtube.com".parse().unwrap(),
     ];


### PR DESCRIPTION
update all hardcoded default URLs, CORS allowed origins, email template links, and OAuth redirect URIs across the codebase from the old groupify.dev domain to the new nestfeed.app domain