### PR TITLE
feat(api/v3): add invoice history and improve webhooks

### DIFF
--- a/src/api/v3/invoices.rs
+++ b/src/api/v3/invoices.rs
@@ -1,0 +1,164 @@
+use axum::{Json, extract::State};
+use serde::Serialize;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use tower_cookies::Cookies;
+use tracing::error;
+
+use crate::{
+    InnerState,
+    api::{common::ApiResponse, v1::user::get_user_id_from_token, v3::entities::subscription_plans_users},
+    errors::AppError,
+};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InvoiceItem {
+    pub payment_id: String,
+    pub total_amount: i32,
+    pub currency: String,
+    pub status: Option<String>,
+    pub created_at: String,
+    pub customer_name: String,
+    pub customer_email: String,
+    pub subscription_id: Option<String>,
+    pub invoice_url: Option<String>,
+    pub refund_status: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InvoicesResponse {
+    pub items: Vec<InvoiceItem>,
+}
+
+#[tracing::instrument(name = "Get Dodo invoice history", skip(cookies, inner))]
+pub async fn get_invoice_history(
+    cookies: Cookies,
+    State(inner): State<InnerState>,
+) -> Result<Json<ApiResponse<InvoicesResponse>>, AppError> {
+    let InnerState { sea_db, .. } = inner;
+
+    let auth_token = cookies
+        .get("auth-token")
+        .map(|c| c.value().to_string())
+        .unwrap_or_default();
+
+    if auth_token.is_empty() {
+        return Err(AppError::Authentication(anyhow::anyhow!("Missing token")));
+    }
+
+    let user_id = get_user_id_from_token(auth_token).await?;
+
+    let dodo_api_key = std::env::var("DODO_API_KEY")
+        .map_err(|_| AppError::BadRequest("DODO_API_KEY not set".to_string()))?;
+
+    let environment = std::env::var("DODO_ENVIRONMENT")
+        .unwrap_or_else(|_| "test_mode".to_string());
+
+    let base_url = match environment.as_str() {
+        "live_mode" => "https://live.dodopayments.com",
+        _ => "https://test.dodopayments.com",
+    };
+
+    let active_sub = subscription_plans_users::Entity::find()
+        .filter(subscription_plans_users::Column::UserId.eq(user_id.clone()))
+        .filter(subscription_plans_users::Column::EndedAt.is_null())
+        .one(&sea_db)
+        .await
+        .map_err(AppError::SeaORM)?;
+
+    let client = reqwest::Client::new();
+    let mut req = client
+        .get(format!("{}/payments", base_url))
+        .header("Authorization", format!("Bearer {}", dodo_api_key))
+        .header("Content-Type", "application/json")
+        .header("Dodo-Environment", &environment);
+
+    if let Some(ref sub) = active_sub {
+        if let Some(ref customer_id) = sub.external_customer_id {
+            req = req.query(&[("customer_id", customer_id)]);
+        }
+    }
+
+    let response = req
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to call Dodo payments API: {}", e);
+            AppError::ExternalService(anyhow::anyhow!("Failed to fetch invoices from Dodo"))
+        })?;
+
+    if !response.status().is_success() {
+        let error_text = response.text().await.unwrap_or_default();
+        error!("Dodo payments API error: {}", error_text);
+        return Err(AppError::ExternalService(anyhow::anyhow!(
+            "Dodo API error: {}",
+            error_text
+        )));
+    }
+
+    let dodo_response: serde_json::Value = response.json().await.map_err(|e| {
+        error!("Failed to parse Dodo payments response: {}", e);
+        AppError::BadRequest("Failed to parse Dodo response".to_string())
+    })?;
+
+    let items = dodo_response
+        .get("items")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|item| InvoiceItem {
+                    payment_id: item
+                        .get("payment_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    total_amount: item
+                        .get("total_amount")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0) as i32,
+                    currency: item
+                        .get("currency")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    status: item
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    created_at: item
+                        .get("created_at")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    customer_name: item
+                        .get("customer")
+                        .and_then(|c| c.get("name"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    customer_email: item
+                        .get("customer")
+                        .and_then(|c| c.get("email"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    subscription_id: item
+                        .get("subscription_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    invoice_url: item
+                        .get("invoice_url")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    refund_status: item
+                        .get("refund_status")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(Json(ApiResponse::success(InvoicesResponse { items })))
+}

--- a/src/api/v3/mod.rs
+++ b/src/api/v3/mod.rs
@@ -7,6 +7,7 @@ pub mod services;
 pub mod share_links;
 pub mod users;
 pub mod payments;
+pub mod invoices;
 pub mod blog;
 pub mod proxy;
 pub mod websites;
@@ -46,6 +47,7 @@ pub fn create_v3_router(state: InnerState) -> Router<InnerState> {
         .route("/api/v3/proxy/fetch-url", post(proxy::fetch_url_metadata))
         .route("/api/v3/payments", post(payments::create_checkout_session))
         .route("/api/v3/payments/cancel", post(payments::cancel_subscription))
+        .route("/api/v3/invoices/history", get(invoices::get_invoice_history))
         .layer(CookieManagerLayer::new())
         .layer(middleware::from_fn(auth_middleware))
         .with_state(state)

--- a/src/api/v3/payments.rs
+++ b/src/api/v3/payments.rs
@@ -25,7 +25,8 @@ pub struct DodoCustomer {
     pub customer_id: String,
     pub email: String,
     pub name: String,
-    pub metadata: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
     #[serde(default)]
     pub phone_number: Option<String>,
 }
@@ -35,12 +36,14 @@ pub struct DodoSubscriptionData {
     pub subscription_id: String,
     pub status: String,
     pub created_at: String,
-    pub expires_at: String,
+    #[serde(default)]
+    pub expires_at: Option<String>,
     pub next_billing_date: String,
     pub product_id: String,
     pub quantity: i32,
     pub customer: DodoCustomer,
-    pub metadata: HashMap<String, serde_json::Value>,
+    #[serde(default)]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
     #[serde(default)]
     pub custom_field_responses: Option<HashMap<String, serde_json::Value>>,
 }
@@ -49,7 +52,8 @@ pub struct DodoSubscriptionData {
 pub struct DodoWebhookPayload {
     #[serde(rename = "type")]
     pub event_type: String,
-    pub business_id: String,
+    #[serde(default)]
+    pub business_id: Option<String>,
     pub data: DodoSubscriptionData,
     pub timestamp: String,
 }
@@ -152,7 +156,8 @@ async fn activate_subscription_from_dodo_webhook(
     payload: &DodoWebhookPayload,
 ) -> Result<(), AppError> {
     // Extract user_id from metadata
-    let user_id = payload.data.metadata.get("user_id")
+    let user_id = payload.data.metadata.as_ref()
+        .and_then(|m| m.get("user_id"))
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
             error!("User ID not found in Dodo webhook metadata: {:?}", payload.data.metadata);
@@ -160,7 +165,8 @@ async fn activate_subscription_from_dodo_webhook(
         })?;
     
     // Extract plan_name from metadata and map to database plan names
-    let dodo_plan_name = payload.data.metadata.get("plan_name")
+    let dodo_plan_name = payload.data.metadata.as_ref()
+        .and_then(|m| m.get("plan_name"))
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
             error!("Plan name not found in Dodo webhook metadata: {:?}", payload.data.metadata);
@@ -274,22 +280,105 @@ async fn activate_subscription_from_dodo_webhook(
 }
 
 /// Handle Dodo webhook for subscription activation
-#[tracing::instrument(name = "Handle Dodo subscription webhook", skip(inner, payload))]
+#[tracing::instrument(name = "Handle Dodo subscription webhook", skip(inner))]
 pub async fn handle_dodo_subscription_webhook(
     State(inner): State<InnerState>,
-    Json(payload): Json<DodoWebhookPayload>,
+    Json(payload): Json<serde_json::Value>,
 ) -> Result<Json<ApiResponse<String>>, AppError> {
-    info!("Received Dodo webhook: {:?}", payload);
-    
-    // Only process subscription.active events
-    if payload.event_type != "subscription.active" {
-        info!("Ignoring Dodo event type: {}", payload.event_type);
-        return Ok(Json(ApiResponse::success("Event ignored".to_string())));
+    let event_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    info!("Received Dodo webhook event: {}", event_type);
+
+    match event_type.as_str() {
+        "subscription.active" | "subscription.renewed" => {
+            let dodo_payload: DodoWebhookPayload = serde_json::from_value(payload)
+                .map_err(|e| {
+                    error!("Failed to deserialize {} payload: {}", event_type, e);
+                    AppError::BadRequest("Invalid webhook payload".to_string())
+                })?;
+            activate_subscription_from_dodo_webhook(&inner, &dodo_payload).await?;
+            Ok(Json(ApiResponse::success("Subscription processed successfully".to_string())))
+        }
+        "payment.succeeded" => {
+            let data = payload.get("data").ok_or_else(|| {
+                AppError::BadRequest("Missing data field in payment webhook".to_string())
+            })?;
+
+            let subscription_id = data.get("subscription_id").and_then(|v| v.as_str());
+            let customer_id = data.get("customer").and_then(|c| c.get("customer_id")).and_then(|v| v.as_str());
+
+            if let Some(sub_id) = subscription_id {
+                if let Some(cus_id) = customer_id {
+                    let db = &inner.sea_db;
+
+                    if let Some(existing_sub) = subscription_plans_users::Entity::find()
+                        .filter(subscription_plans_users::Column::ExternalSubscriptionId.eq(sub_id))
+                        .one(db)
+                        .await
+                        .map_err(AppError::SeaORM)?
+                    {
+                        if existing_sub.external_customer_id.is_none() {
+                            let mut active_model: subscription_plans_users::ActiveModel = existing_sub.into();
+                            active_model.external_customer_id = Set(Some(cus_id.to_string()));
+                            active_model.update(db).await.map_err(AppError::SeaORM)?;
+                            info!("Updated external_customer_id for subscription {}", sub_id);
+                        }
+                    } else {
+                        let user_id = data.get("metadata").and_then(|m| m.get("user_id")).and_then(|v| v.as_str());
+                        let plan_name = data.get("metadata").and_then(|m| m.get("plan_name")).and_then(|v| v.as_str());
+
+                        if let (Some(uid), Some(pname)) = (user_id, plan_name) {
+                            let db_plan_name = match pname {
+                                "Basic" => "Groupify Basic Monthly",
+                                "Pro" => "Groupify Pro Monthly",
+                                _ => {
+                                    error!("Unknown plan name from payment webhook: {}", pname);
+                                    return Err(AppError::BadRequest(format!("Unknown plan: {}", pname)));
+                                }
+                            };
+
+                            let user = crate::api::v3::entities::users::Entity::find()
+                                .filter(crate::api::v3::entities::users::Column::Id.eq(uid))
+                                .one(db)
+                                .await
+                                .map_err(AppError::SeaORM)?
+                                .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+
+                            let plan = crate::api::v3::entities::subscription_plans::Entity::find()
+                                .filter(crate::api::v3::entities::subscription_plans::Column::Name.eq(db_plan_name))
+                                .one(db)
+                                .await
+                                .map_err(AppError::SeaORM)?
+                                .ok_or_else(|| AppError::NotFound("Plan not found".to_string()))?;
+
+                            let created_at_str = data.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
+                            let created_at = chrono::DateTime::parse_from_rfc3339(created_at_str).ok();
+
+                            let new_sub = subscription_plans_users::ActiveModel {
+                                user_id: Set(user.id.clone()),
+                                subscription_plan_id: Set(plan.id),
+                                started_at: Set(created_at.map(|dt| dt.fixed_offset())),
+                                ended_at: Set(None),
+                                created_at: Set(Some(Utc::now().fixed_offset())),
+                                updated_at: Set(Some(Utc::now().fixed_offset())),
+                                external_subscription_id: Set(Some(sub_id.to_string())),
+                                external_customer_id: Set(Some(cus_id.to_string())),
+                                ..Default::default()
+                            };
+
+                            new_sub.insert(db).await.map_err(AppError::SeaORM)?;
+                            info!("Created subscription from payment.succeeded webhook for user {}", uid);
+                        }
+                    }
+                }
+            }
+
+            Ok(Json(ApiResponse::success("Payment processed".to_string())))
+        }
+        _ => {
+            info!("Ignoring Dodo event type: {}", event_type);
+            Ok(Json(ApiResponse::success("Event ignored".to_string())))
+        }
     }
-    
-    activate_subscription_from_dodo_webhook(&inner, &payload).await?;
-    
-    Ok(Json(ApiResponse::success("Subscription activated successfully".to_string())))
 }
 
 /// Cancel the user's subscription


### PR DESCRIPTION
Add new `invoices` API module and register the `/api/v3/invoices/history` route to fetch authenticated users' invoice history from Dodo Payments API. Update payment webhook handling to support `payment.succeeded` and `subscription.renewed` events in addition to the existing `subscription.active`. Refine Dodo webhook payload structs to handle optional fields with `serde(default)` and update metadata access logic to match. Register the new invoices module in the v3 API exports.