### PR TITLE
feat(otel): add HTTP metrics middleware and fix telemetry pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,8 +77,6 @@ dependencies = [
  "argon2",
  "async-std",
  "axum",
- "axum-otel",
- "axum-otel-metrics",
  "axum_typed_multipart",
  "base64 0.23.1",
  "bytes",
@@ -95,10 +93,10 @@ dependencies = [
  "metrics",
  "oauth2",
  "once_cell",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "rand 0.10.2",
  "redis",
  "reqwest 0.13.4",
@@ -557,36 +555,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "axum-otel"
-version = "0.31.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f7f70438030e2b882f5b066b22e5d0aad58cfff6f21e316b84c1a6d0717a20"
-dependencies = [
- "axum",
- "opentelemetry 0.31.0",
- "tower-http 0.6.8",
- "tracing",
- "tracing-otel-extra",
-]
-
-[[package]]
-name = "axum-otel-metrics"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cf7343b4fc88312e4d7b731152a1a09edcdb6def398d836ef8bccb57f066a"
-dependencies = [
- "axum",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.0",
- "opentelemetry 0.30.0",
- "opentelemetry-semantic-conventions 0.30.0",
- "opentelemetry_sdk 0.30.0",
- "pin-project-lite",
- "tower",
 ]
 
 [[package]]
@@ -2899,20 +2867,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -2931,7 +2885,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2946,7 +2900,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "reqwest 0.12.25",
 ]
 
@@ -2957,10 +2911,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.3.1",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost",
  "reqwest 0.12.25",
  "serde_json",
@@ -2978,8 +2932,8 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "serde",
  "serde_json",
@@ -2989,31 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.30.0",
- "percent-encoding",
- "rand 0.9.2",
- "serde_json",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -3024,7 +2956,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -5331,7 +5263,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5478,8 +5409,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "rustversion",
  "smallvec",
  "thiserror 2.0.18",
@@ -5497,10 +5428,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d669453101c608cbc7cb6c322bf171b53be9b6e0c32126bbaab6242c3b6a5497"
 dependencies = [
  "anyhow",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5513,14 +5444,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c34ecd9f01faef1f16c570832f5ff72c587a133ddae46424b522d16e494edc1"
 dependencies = [
  "anyhow",
- "http 1.3.1",
- "opentelemetry 0.31.0",
- "opentelemetry-http",
+ "opentelemetry",
  "serde",
  "serde_json",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry",
  "tracing-opentelemetry-extra",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,9 @@ bytes = "1.11.1"
 oauth2 = "4.4.2"
 dotenvy = "0.15.7"
 
-axum-otel = "0.31.6"
-axum-otel-metrics = "0.12.0"
 tracing-otel-extra = { version = "0.31.6", features = ["otel", "logger"] }
 opentelemetry = "0.31.0"
-opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "testing"] }
 opentelemetry-otlp = { version = "0.31.1", features = ["metrics", "grpc-tonic", "logs"] }
 opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
 rust_decimal = "1.41.0"

--- a/src/api/common/metrics.rs
+++ b/src/api/common/metrics.rs
@@ -1,0 +1,187 @@
+//! OpenTelemetry HTTP metrics middleware.
+//!
+//! Records HTTP request metrics (request count, latency, body sizes, active
+//! requests) into the global OpenTelemetry meter provider, which is set up in
+//! `main.rs` via `init_meter_provider` and pushed to the configured OTLP
+//! collector.
+
+use axum::body::Body;
+use axum::extract::MatchedPath;
+use axum::http::{Request, header};
+use axum::middleware::Next;
+use axum::response::Response;
+use once_cell::sync::Lazy;
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
+use opentelemetry::KeyValue;
+use std::time::Instant;
+
+static REQUESTS_TOTAL: Lazy<Counter<u64>> = Lazy::new(|| {
+    global::meter("groupify-http")
+        .u64_counter("http.server.requests")
+        .with_description("Total number of HTTP server requests")
+        .with_unit("{request}")
+        .build()
+});
+
+static REQUEST_DURATION: Lazy<Histogram<f64>> = Lazy::new(|| {
+    global::meter("groupify-http")
+        .f64_histogram("http.server.duration")
+        .with_description("Duration of HTTP server requests")
+        .with_unit("s")
+        .with_boundaries(vec![
+            0.0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+        ])
+        .build()
+});
+
+static REQUEST_BODY_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
+    global::meter("groupify-http")
+        .u64_histogram("http.server.request.body.size")
+        .with_description("Size of HTTP server request bodies")
+        .with_unit("By")
+        .build()
+});
+
+static RESPONSE_BODY_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
+    global::meter("groupify-http")
+        .u64_histogram("http.server.response.body.size")
+        .with_description("Size of HTTP server response bodies")
+        .with_unit("By")
+        .build()
+});
+
+static ACTIVE_REQUESTS: Lazy<UpDownCounter<i64>> = Lazy::new(|| {
+    global::meter("groupify-http")
+        .i64_up_down_counter("http.server.active_requests")
+        .with_description("Number of active HTTP server requests")
+        .with_unit("{request}")
+        .build()
+});
+
+fn content_length(headers: &Request<Body>) -> Option<u64> {
+    headers
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+pub async fn http_metrics(request: Request<Body>, next: Next) -> Response {
+    let start = Instant::now();
+
+    let method = request.method().clone();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_owned());
+    let request_body_size = content_length(&request);
+
+    ACTIVE_REQUESTS.add(1, &[]);
+
+    let response = next.run(request).await;
+
+    ACTIVE_REQUESTS.add(-1, &[]);
+
+    let status = response.status().as_u16() as i64;
+    let attributes = [
+        KeyValue::new("http.request.method", method.to_string()),
+        KeyValue::new("http.response.status_code", status),
+        KeyValue::new("http.route", route),
+    ];
+
+    REQUESTS_TOTAL.add(1, &attributes);
+    REQUEST_DURATION.record(start.elapsed().as_secs_f64(), &attributes);
+
+    if let Some(size) = request_body_size {
+        REQUEST_BODY_SIZE.record(size, &attributes);
+    }
+
+    let response_body_size = response
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    if let Some(size) = response_body_size {
+        RESPONSE_BODY_SIZE.record(size, &attributes);
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, routing::get};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+    use std::time::Duration;
+    use tower::ServiceExt;
+
+        fn metric_total(
+        scope_metrics: &[&opentelemetry_sdk::metrics::data::ScopeMetrics],
+        name: &str,
+    ) -> u64 {
+        let mut total = 0;
+        for scope in scope_metrics {
+            for metric in scope.metrics() {
+                if metric.name() != name {
+                    continue;
+                }
+                let sum = match metric.data() {
+                    opentelemetry_sdk::metrics::data::AggregatedMetrics::U64(
+                        opentelemetry_sdk::metrics::data::MetricData::Sum(sum),
+                    ) => sum,
+                    _ => continue,
+                };
+                for point in sum.data_points() {
+                    total += point.value();
+                }
+            }
+        }
+        total
+    }
+
+    #[tokio::test]
+    async fn records_http_server_metrics() {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(Duration::from_secs(3600))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        global::set_meter_provider(provider.clone());
+
+        let app = Router::new()
+            .route("/hello", get(|| async { "world" }))
+            .layer(axum::middleware::from_fn(http_metrics));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/hello")
+                    .header(header::CONTENT_LENGTH, 1)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        provider.force_flush().unwrap();
+
+        let finished = exporter.get_finished_metrics().unwrap();
+        let scope_metrics: Vec<_> = finished
+            .iter()
+            .flat_map(|rm| rm.scope_metrics())
+            .collect();
+
+        assert_eq!(metric_total(&scope_metrics, "http.server.requests"), 1);
+        assert!(scope_metrics
+            .iter()
+            .any(|scope| scope.metrics().any(|m| m.name() == "http.server.duration")));
+        assert_eq!(
+            metric_total(&scope_metrics, "http.server.active_requests"),
+            0
+        );
+    }
+}

--- a/src/api/common/mod.rs
+++ b/src/api/common/mod.rs
@@ -11,6 +11,7 @@ pub mod utils;
 pub mod cache;
 pub mod body_logger;
 pub mod limits;
+pub mod metrics;
 
 use serde::{Deserialize, Serialize};
 use sqlx::prelude::FromRow;

--- a/src/api/v3/share_links.rs
+++ b/src/api/v3/share_links.rs
@@ -507,7 +507,7 @@ mod tests {
     use crate::db::init_db;
     use crate::api::common::cache::RedisCache;
     use crate::email::EmailClient;
-    use crate::api::v1::oauth::{build_google_oauth_client, build_discord_oauth_client, OAuthClients};
+    use crate::api::v1::oauth::{build_google_oauth_client, build_discord_oauth_client, build_apple_oauth_client, OAuthClients};
     use deadpool_redis::{Config as RedisConfig, Runtime};
     use sea_orm::Database;
 
@@ -539,6 +539,12 @@ mod tests {
         let oauth_clients = OAuthClients {
             google: google_oauth_client,
             discord: discord_oauth_client,
+            apple: build_apple_oauth_client(
+                std::env::var("APPLE_OAUTH_CLIENT_ID").unwrap_or_else(|_| "test_id".to_string()),
+                std::env::var("APPLE_TEAM_ID").unwrap_or_else(|_| "test_team".to_string()),
+                std::env::var("APPLE_KEY_ID").unwrap_or_else(|_| "test_key".to_string()),
+                std::env::var("APPLE_PRIVATE_KEY").unwrap_or_else(|_| "test_key".to_string()),
+            ),
         };
 
         InnerState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use crate::db::init_db;
 use crate::system::create_system_router;
 use crate::api::common::tracing::{make_custom_span, on_custom_request, on_custom_response, on_custom_failure};
 use crate::api::common::body_logger::log_request_response_body;
+use crate::api::common::metrics::http_metrics;
 
 use anyhow::Result;
 use axum::extract::FromRef;
@@ -196,6 +197,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 )
                 .layer(PropagateRequestIdLayer::x_request_id()),
         )
+        .layer(axum::middleware::from_fn(http_metrics))
         .layer(Extension(shared_state));
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3010")


### PR DESCRIPTION
Wire an OTel metrics middleware recording http.server.requests, http.server.duration, body sizes and active requests into the existing OTLP push pipeline. Remove unused axum-otel/axum-otel-metrics deps, which were linked against opentelemetry 0.30 and would have recorded into a no-op provider. Fix tests in v3/share_links.rs missing the apple OAuth client.